### PR TITLE
Add workflows for CI/CD

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -1,0 +1,54 @@
+name: CD
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
+      - run: npm ci
+      - run: npm run validate
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-18.04
+    needs: test
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
+      - run: npm ci
+      - run: npm run build
+      - run: |
+          echo "$CLASP_AUTH" | base64 -d - > ~/.clasprc.json
+          echo "{\"scriptId\": \"${CLASP_ID}\"}" > .clasp.json
+          npm run clasp:push
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          CLASP_ID: ${{ secrets.CLASP_ID }}
+          CLASP_AUTH: ${{ secrets.CLASP_AUTH }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
+      - run: npm ci
+      - run: npm run validate

--- a/package.json
+++ b/package.json
@@ -1,16 +1,21 @@
 {
-  "name": "clasp_learning",
+  "name": "portfolio-gsheets",
   "version": "1.0.0",
-  "description": "Clasp learning and project best practices",
+  "description": "Code used by the GSheets Porfolio document",
   "scripts": {
     "build": "tsc",
     "prettier": "prettier \"**/*.+(js|ts|json|md)\"",
     "format": "npm run prettier -- --write",
     "check-format": "npm run prettier -- --list-different",
-    "test": "jest --watch",
+    "test": "jest",
+    "test:tdd": "jest --watch",
     "test:coverage": "jest --coverage",
     "validate": "npm run check-format && npm run build && npm run test",
-    "clasp:push": "npm run validate && clasp push"
+    "clasp:push": "clasp push"
+  },
+  "engines": {
+    "node": "^12.16.0",
+    "npm": "^6.14.0"
   },
   "jest": {
     "testEnvironment": "jest-environment-node",


### PR DESCRIPTION
Now there are two workflows to help validate our code automatically on pushes.

The first one is CI, responsible for validating our code on pushes, independently of branches. The second one, which is CD, runs validations as CI, and beyond that, it'll push the built code using `clasp`.

For CD, given that it interacts with a project on Google App Scripts, we need to configure `clasp` for the target project and authenticate with the correct user; both of those secrets must exist on GitHub Secrets (duh?), respectively, as `CLASP_ID` and `CLASP_AUTH`. Regarding the values, `CLASP_ID` is just a string, while `CLASP_AUTH` consists of the contents from `~/.clasprc.json` encoded with `base64`.